### PR TITLE
Add port arg to pduSynaccess constructor

### DIFF
--- a/pduSynaccess/pduSynaccess/pduSynaccess.py
+++ b/pduSynaccess/pduSynaccess/pduSynaccess.py
@@ -43,9 +43,9 @@ import sys
 import time
 
 class pdu:
-  def __init__(self, uri, ch=None, loglevel=logging.ERROR):
+  def __init__(self, uri, ch=None, port=23, loglevel=logging.ERROR):
     self._uri = uri
-    self._port = 23
+    self._port = port
     self._ch = ch
     logging.basicConfig(format = '%(levelname)s:%(name)s:%(message)s', level=loglevel)
     self._log = logging.getLogger(__name__)


### PR DESCRIPTION
# Summary

as title suggests

# Tests

I tested this on one of the channels of a pduSynaccess device.  With the `HEAD` commit of this branch checked out, and after instantiating one `pdu`, I did:

1) **_off_**
console print statement from device:
```bash
INFO:pduSynaccess.pduSynaccess:Set Ch1=OFF => OK
```
try to ping the device that was obtaining power from the channel which was switched off:
```bash
$ ping -c 2 172.16.3.1
PING 172.16.3.1 (172.16.3.1) 56(84) bytes of data.

--- 172.16.3.1 ping statistics ---
2 packets transmitted, 0 received, 100% packet loss, time 1016ms
```
2) _**on**_
console print statement from device:
```bash
INFO:pduSynaccess.pduSynaccess:Set Ch1=ON => OK
```
ping the device that was obtaining power from the channel which is now on:
```bash
$ ping -c 2 172.16.3.1
PING 172.16.3.1 (172.16.3.1) 56(84) bytes of data.
64 bytes from 172.16.3.1: icmp_seq=1 ttl=64 time=1.22 ms
64 bytes from 172.16.3.1: icmp_seq=2 ttl=64 time=1.22 ms

--- 172.16.3.1 ping statistics ---
2 packets transmitted, 2 received, 0% packet loss, time 1001ms
rtt min/avg/max/mdev = 1.220/1.221/1.222/0.001 ms
```
